### PR TITLE
Add request_time attribute to RWSConnection

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -117,6 +117,21 @@ Having access to ``last_result`` means that rwslib never hides it's workings fro
 be a helper library to get your own integrations up and running, it tries not to hide implementation
 details from you.
 
+Getting the elapsed time of the request
+---------------------------------------
+
+Each time ``RWSConnection`` sends a request and receives results it keeps the elapsed time, in seconds, of the RWS call
+in it's ``request_time`` attribute.
+
+    >>> from rwslib import RWSConnection
+    >>> from rwslib.rws_requests import VersionRequest
+    >>> rws = RWSConnection('innovate')
+    >>> #Get the rave version from rws
+    >>> rws.send_request(VersionRequest())
+    1.8.0
+    >>> #Get the elapsed time in seconds to process the previous request
+    >>> rws.request_time
+    0.760736942291
 
 Error Handling
 --------------

--- a/rwslib/__init__.py
+++ b/rwslib/__init__.py
@@ -13,6 +13,8 @@ from urllib import urlencode
 from rws_requests import RWSRequest, make_url
 from rwsobjects import RWSException, RWSError, RWSErrorResponse
 
+import time
+
 #-------------------------------------------------------------------------------------------------------
 # Classes
 #
@@ -50,6 +52,9 @@ class RWSConnection(object):
         #Keep track of results of last request so users can get if they need.
         self.last_result = None
 
+        #Time taken to process last request
+        self.request_time = None
+
 
     def get_auth(self):
         """Get authorization headers"""
@@ -78,7 +83,9 @@ class RWSConnection(object):
         action = {"GET": requests.get,
                   "POST": requests.post}[request_object.method]
 
+        start_time = time.time()
         r = action(full_url, **kwargs)
+        self.request_time = time.time() - start_time
         self.last_result = r
 
         if r.status_code in [400, 404]:

--- a/rwslib/example.py
+++ b/rwslib/example.py
@@ -29,6 +29,7 @@ if __name__ == '__main__':
     print len(studies)
     print rave.last_result.url
     print rave.last_result.text
+    print rave.request_time
 
     print "Metadata studies request"
     m_studies = rave.send_request(MetadataStudiesRequest())

--- a/rwslib/tests/test_rwslib.py
+++ b/rwslib/tests/test_rwslib.py
@@ -36,5 +36,23 @@ class TestMustBeRWSRequestSubclass(unittest.TestCase):
         self.assertRaises(ValueError, do)
 
 
+class RequestTime(unittest.TestCase):
+    """Test for the last request time property"""
+    @httpretty.activate
+    def test_request_time(self):
+        """A simple test, patching the get request so that it does not hit a website"""
+
+        httpretty.register_uri(
+            httpretty.GET, "https://innovate.mdsol.com/RaveWebServices/version",
+            status=200,
+            body="1.0.0")
+
+        #Now my test
+        rave = rwslib.RWSConnection('https://innovate.mdsol.com')
+        v = rave.send_request(rwslib.rws_requests.VersionRequest())
+        request_time = rave.request_time
+        self.assertIs(type(request_time),float)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
request_time stores the elapsed time, in seconds, of the last request
sent to RWS
