### PR TITLE
Added the ability to pass a datetime.datetime as the start argument

### DIFF
--- a/rwslib/rws_requests/__init__.py
+++ b/rwslib/rws_requests/__init__.py
@@ -7,6 +7,7 @@ as appropriate.
 TODO: Note that might want to make the Request objects responsible for deciding whether they are get, post, patch etc.
 
 """
+import datetime
 
 from rwslib.rwsobjects import RWSResponse, RWSStudies, RWSStudyMetadataVersions, RWSSubjects, \
     RWSPostResponse
@@ -21,6 +22,23 @@ def check_dataset_type(dataset_type):
     if dataset_type.lower() not in ['regular', 'raw']:
         raise ValueError("Dataset type not 'regular' or 'raw' is %s" % dataset_type)
 
+
+def format_date_argument(date_element):
+    """
+    Take a date as either a datetime.date/datetime or a string and return it as a
+     iso8601 formatted value
+    :param date_element: passed argument
+    :return:
+    """
+    if not isinstance(date_element, (datetime.datetime, datetime.date,)):
+        # TODO:
+        if 'T' in date_element:
+            _date = datetime.datetime.strptime(date_element, "%Y-%m-%dT%H:%M:%S")
+        else:
+            _date = datetime.datetime.strptime(date_element, "%Y-%m-%d").date()
+    else:
+        _date = date_element
+    return _date.isoformat()
 
 # -------------------------------------------------------------------------------------------------------
 # Utility functions
@@ -380,7 +398,6 @@ class ODMDatasetBase(RWSAuthorizedGetRequest):
 
     def checkParams(self):
         check_dataset_type(self.dataset_type)
-        # TODO: Check start is an iso8601 date.
         # https://bitbucket.org/micktwomey/pyiso8601
 
     def _querystring(self):
@@ -391,7 +408,14 @@ class ODMDatasetBase(RWSAuthorizedGetRequest):
         for key in self.KNOWN_QUERY_OPTIONS:
             val = getattr(self, key)
             if val is not None:
-                kw[key] = val
+                if key == 'start':
+                    # special case the date formatting
+                    # this will raise a ValueError
+                    # if the date format is a string and not one of
+                    # YYYY-mm-ddTHH:MM:SS or YYYY-mm-dd
+                    kw[key] = format_date_argument(val)
+                else:
+                    kw[key] = val
         return kw
 
     def _studyname_environment(self):

--- a/rwslib/rws_requests/__init__.py
+++ b/rwslib/rws_requests/__init__.py
@@ -35,7 +35,7 @@ def format_date_argument(date_element):
         if 'T' in date_element:
             _date = datetime.datetime.strptime(date_element, "%Y-%m-%dT%H:%M:%S")
         else:
-            _date = datetime.datetime.strptime(date_element, "%Y-%m-%d")
+            _date = datetime.datetime.strptime(date_element, "%Y-%m-%d").date()
     else:
         _date = date_element
     return _date.isoformat()

--- a/rwslib/rws_requests/__init__.py
+++ b/rwslib/rws_requests/__init__.py
@@ -35,7 +35,7 @@ def format_date_argument(date_element):
         if 'T' in date_element:
             _date = datetime.datetime.strptime(date_element, "%Y-%m-%dT%H:%M:%S")
         else:
-            _date = datetime.datetime.strptime(date_element, "%Y-%m-%d").date()
+            _date = datetime.datetime.strptime(date_element, "%Y-%m-%d")
     else:
         _date = date_element
     return _date.isoformat()

--- a/rwslib/tests/test_rws_requests.py
+++ b/rwslib/tests/test_rws_requests.py
@@ -195,7 +195,7 @@ class TestSubjectDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01T00%3A00%3A00",
+        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01",
                          t.url_path())
 
 
@@ -269,7 +269,7 @@ class TestVersionDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
+        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01", t.url_path())
 
 
 class TestStudyDatasetRequest(unittest.TestCase):
@@ -348,7 +348,7 @@ class TestStudyDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
+        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01", t.url_path())
 
 
 class TestPostDataRequest(unittest.TestCase):

--- a/rwslib/tests/test_rws_requests.py
+++ b/rwslib/tests/test_rws_requests.py
@@ -195,7 +195,8 @@ class TestSubjectDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
+        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01",
+                         t.url_path())
 
 
 class TestVersionDatasetRequest(unittest.TestCase):
@@ -268,7 +269,7 @@ class TestVersionDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
+        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01", t.url_path())
 
 
 class TestStudyDatasetRequest(unittest.TestCase):
@@ -347,7 +348,7 @@ class TestStudyDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
+        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01", t.url_path())
 
 
 class TestPostDataRequest(unittest.TestCase):

--- a/rwslib/tests/test_rws_requests.py
+++ b/rwslib/tests/test_rws_requests.py
@@ -195,7 +195,7 @@ class TestSubjectDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01",
+        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01T00%3A00%3A00",
                          t.url_path())
 
 
@@ -269,7 +269,7 @@ class TestVersionDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01", t.url_path())
+        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
 
 
 class TestStudyDatasetRequest(unittest.TestCase):
@@ -348,7 +348,7 @@ class TestStudyDatasetRequest(unittest.TestCase):
         t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
         self.assertEqual("Mediflex", t.project_name)
         self.assertEqual("Prod", t.environment_name)
-        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01", t.url_path())
+        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
 
 
 class TestPostDataRequest(unittest.TestCase):

--- a/rwslib/tests/test_rws_requests.py
+++ b/rwslib/tests/test_rws_requests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import datetime
 
 __author__ = 'glow'
 
@@ -16,7 +17,7 @@ from rwslib.rws_requests import StudySubjectsRequest, check_dataset_type, Subjec
     GlobalLibraryVersionRequest, GlobalLibraryVersionsRequest, GlobalLibraryDraftsRequest, \
     GlobalLibrariesRequest, StudyVersionRequest, StudyVersionsRequest, StudyDraftsRequest, \
     MetadataStudiesRequest, ClinicalStudiesRequest, CacheFlushRequest, DiagnosticsRequest, \
-    BuildVersionRequest
+    BuildVersionRequest, ODMDatasetBase
 
 
 class TestStudySubjectsRequest(unittest.TestCase):
@@ -174,6 +175,28 @@ class TestSubjectDatasetRequest(unittest.TestCase):
         self.assertEqual("Dataset type not 'regular' or 'raw' is pineapple",
                          str(exc.exception))
 
+    def test_create_start_using_datetime(self):
+        """We can pass a datetime instance as the start argument"""
+        jan = datetime.datetime(year=2012, month=12, day=1, hour=12, minute=12, second=23)
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start=jan)
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01T12%3A12%3A23", t.url_path())
+
+    def test_create_start_using_string_datetime(self):
+        """We can pass a string (iso8601) instance as the start argument"""
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01T12:12:23")
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01T12%3A12%3A23", t.url_path())
+
+    def test_create_start_using_string_date(self):
+        """We can pass a string (iso8601) instance as the start argument"""
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/subjects/1001/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
+
 
 class TestVersionDatasetRequest(unittest.TestCase):
     def create_request_object(self, **kwargs):
@@ -224,6 +247,28 @@ class TestVersionDatasetRequest(unittest.TestCase):
             t = self.create_request_object(dataset_type="pineapple")
         self.assertEqual("Dataset type not 'regular' or 'raw' is pineapple",
                         str(exc.exception))
+
+    def test_create_start_using_datetime(self):
+        """We can pass a datetime instance as the start argument"""
+        jan = datetime.datetime(year=2012, month=12, day=1, hour=12, minute=12, second=23)
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start=jan)
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01T12%3A12%3A23", t.url_path())
+
+    def test_create_start_using_string_datetime(self):
+        """We can pass a string (iso8601) instance as the start argument"""
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01T12:12:23")
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01T12%3A12%3A23", t.url_path())
+
+    def test_create_start_using_string_date(self):
+        """We can pass a string (iso8601) instance as the start argument"""
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/versions/1001/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
 
 
 class TestStudyDatasetRequest(unittest.TestCase):
@@ -281,6 +326,29 @@ class TestStudyDatasetRequest(unittest.TestCase):
             t = self.create_request_object(dataset_type="pineapple")
         self.assertEqual("Dataset type not 'regular' or 'raw' is pineapple",
                          str(exc.exception))
+
+    def test_create_start_using_datetime(self):
+        """We can pass a datetime instance as the start argument"""
+        jan = datetime.datetime(year=2012, month=12, day=1, hour=12, minute=12, second=23)
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start=jan)
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01T12%3A12%3A23", t.url_path())
+
+    def test_create_start_using_string_datetime(self):
+        """We can pass a string (iso8601) instance as the start argument"""
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01T12:12:23")
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01T12%3A12%3A23", t.url_path())
+
+    def test_create_start_using_string_date(self):
+        """We can pass a string (iso8601) instance as the start argument"""
+        t = self.create_request_object(dataset_type="raw", formoid="DM", start="2012-12-01")
+        self.assertEqual("Mediflex", t.project_name)
+        self.assertEqual("Prod", t.environment_name)
+        self.assertEqual("studies/Mediflex(Prod)/datasets/raw/DM?start=2012-12-01T00%3A00%3A00", t.url_path())
+
 
 class TestPostDataRequest(unittest.TestCase):
     def test_post_data_request_response(self):

--- a/rwslib/tests/test_rws_requests.py
+++ b/rwslib/tests/test_rws_requests.py
@@ -760,33 +760,6 @@ class TestBuildVersionRequest(unittest.TestCase):
         self.assertEqual("version/build", t.url_path())
 
 
-class TestODMDatasetBase(unittest.TestCase):
-    def test_KNOWN_QUERY_OPTIONS_versionitem(self):
-        """We check if the 'versionitem' keyword is in the KNOWN_QUERY_OPTIONS"""
-        self.assertTrue("versionitem" in ODMDatasetBase.KNOWN_QUERY_OPTIONS)
-
-    def test_KNOWN_QUERY_OPTIONS_rawsuffix(self):
-        """We check if the 'rawsuffix' keyword is in the KNOWN_QUERY_OPTIONS"""
-        self.assertTrue("rawsuffix" in ODMDatasetBase.KNOWN_QUERY_OPTIONS)
-
-    def test_KNOWN_QUERY_OPTIONS_codelistsuffix(self):
-        """We check if the 'codelistsuffix' keyword is in the KNOWN_QUERY_OPTIONS"""
-        self.assertTrue("codelistsuffix" in ODMDatasetBase.KNOWN_QUERY_OPTIONS)
-
-    def test_KNOWN_QUERY_OPTIONS_decodesuffix(self):
-        """We check if the 'decodesuffix' keyword is in the KNOWN_QUERY_OPTIONS"""
-        self.assertTrue("decodesuffix" in ODMDatasetBase.KNOWN_QUERY_OPTIONS)
-
-    def test_KNOWN_QUERY_OPTIONS_stdsuffix(self):
-        """We check if the 'stdsuffix' keyword is in the KNOWN_QUERY_OPTIONS"""
-        self.assertTrue("stdsuffix" in ODMDatasetBase.KNOWN_QUERY_OPTIONS)
-
-    def test_KNOWN_QUERY_OPTIONS_start(self):
-        """We check if the 'start' keyword is in the KNOWN_QUERY_OPTIONS"""
-        self.assertTrue("start" in ODMDatasetBase.KNOWN_QUERY_OPTIONS)
-
-
-
 class TimeoutTest(unittest.TestCase):
     """
     Strictly belongs in test_rwslib but it interacts with HttPretty which is used in that unit


### PR DESCRIPTION
@isparks @anewbigging 
* Fixed a missing import in the test cases
* added the ability to pass in a datetime, or string instance for the start parameter