### PR TITLE
Bug content type with charset

### DIFF
--- a/rwslib/__init__.py
+++ b/rwslib/__init__.py
@@ -122,7 +122,10 @@ class RWSConnection(object):
             if '<h2>HTTP Error 401.0 - Unauthorized</h2>' in r.text:
                 raise RWSException("Unauthorized.", r.text)
 
-            if r.headers.get('content-type') == "text/xml":
+            # Check if the content_type is text/xml.  Use startswith
+            # in case the charset is also specified:
+            #  content-type: text/xml; charset=utf-8
+            if r.headers.get('content-type').startswith("text/xml"):
                 # XML response
                 if r.text.startswith('<Response'):
                     error = RWSErrorResponse(r.text)


### PR DESCRIPTION
In case of an 401 error (authentication failure), the message received from the server is not correctly processed if the charset is specified in the content-type part of the header (https://www.w3.org/International/articles/http-charset/index).

Modification: instead of strictly checking for "text/xml", the startswith command is used.

