### PR TITLE
Fix handling unauthorized

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Authors
 - Oli Quinet <https://github.com/Oli76>
 - Daniel Smoczyk <https://github.com/dPeS>
 - Bastien Gerard <https://github.com/bagerard>
+- Filip Janowski <https://github.com/filip75>

--- a/rwslib/__init__.py
+++ b/rwslib/__init__.py
@@ -3,7 +3,7 @@
 __title__ = "rwslib"
 __author__ = "Ian Sparks (isparks@trialgrid.com)"
 __maintainer__ = "Geoff Low (glow@mdsol.com)"
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 __license__ = "MIT"
 __copyright__ = "Copyright 2021 Medidata Solutions Inc"
 

--- a/rwslib/__init__.py
+++ b/rwslib/__init__.py
@@ -147,7 +147,7 @@ class RWSConnection(object):
             if r.text == "Authorization Header not provided":
                 raise AuthorizationException(r.text)
 
-            if "<h2>HTTP Error 401.0 - Unauthorized</h2>" in r.text:
+            if "HTTP Error 401.0 - Unauthorized" in r.text:
                 raise RWSException("Unauthorized.", r.text)
 
             # Check if the content_type is text/xml.  Use startswith

--- a/rwslib/tests/test_rwslib.py
+++ b/rwslib/tests/test_rwslib.py
@@ -270,7 +270,7 @@ class TestErrorResponse(unittest.TestCase):
     def test_401_error_error_response_unauthorized(self):
         """Parse the IIS Response Error structure"""
 
-        text = b"<h2>HTTP Error 401.0 - Unauthorized</h2>"
+        text = b"<h3>HTTP Error 401.0 - Unauthorized</h3>"
 
         httpretty.register_uri(
             httpretty.POST,


### PR DESCRIPTION
Actual IIS error message is different than what is expected. `<h3>HTTP Error 401.0 - Unauthorized</h3>` rather than `<h2>HTTP Error 401.0 - Unauthorized</h2>`. I removed h3 tag completely from the pattern to avoid issues in the future.

```
Traceback (most recent call last):
  File "/rwslib/rwslib/rwsobjects.py", line 47, in parseXMLString
    return etree.fromstring(xml.encode("utf-8"), parser=parser)
  File "src/lxml/etree.pyx", line 3237, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1896, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1784, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1141, in lxml.etree._BaseParser._parseDoc
  File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 654, in lxml.etree._raiseParseError
  File "<string>", line 69
lxml.etree.XMLSyntaxError: Entity 'nbsp' not defined, line 69, column 46

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 7, in <module>
    connection.send_request(request)
  File "/rwslib/rwslib/__init__.py", line 164, in send_request
    error = RWSErrorResponse(r.text)
  File "/rwslib/rwslib/rwsobjects.py", line 142, in __init__
    XMLRepr.__init__(self, xml)
  File "/rwslib/rwslib/rwsobjects.py", line 71, in __init__
    self.root = parseXMLString(xml)
  File "/rwslib/rwslib/rwsobjects.py", line 49, in parseXMLString
    raise Exception(xml)
Exception: <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"> 
<html xmlns="http://www.w3.org/1999/xhtml"> 
<head> 
<title>IIS 10.0 Detailed Error - 401.0 - Unauthorized</title> 
<style type="text/css"> 
<!-- 
body{margin:0;font-size:.7em;font-family:Verdana,Arial,Helvetica,sans-serif;} 
code{margin:0;color:#006600;font-size:1.1em;font-weight:bold;} 
.config_source code{font-size:.8em;color:#000000;} 
pre{margin:0;font-size:1.4em;word-wrap:break-word;} 
ul,ol{margin:10px 0 10px 5px;} 
ul.first,ol.first{margin-top:5px;} 
fieldset{padding:0 15px 10px 15px;word-break:break-all;} 
.summary-container fieldset{padding-bottom:5px;margin-top:4px;} 
legend.no-expand-all{padding:2px 15px 4px 10px;margin:0 0 0 -12px;} 
legend{color:#333333;;margin:4px 0 8px -12px;_margin-top:0px; 
font-weight:bold;font-size:1em;} 
a:link,a:visited{color:#007EFF;font-weight:bold;} 
a:hover{text-decoration:none;} 
h1{font-size:2.4em;margin:0;color:#FFF;} 
h2{font-size:1.7em;margin:0;color:#CC0000;} 
h3{font-size:1.4em;margin:10px 0 0 0;color:#CC0000;} 
h4{font-size:1.2em;margin:10px 0 5px 0; 
}#header{width:96%;margin:0 0 0 0;padding:6px 2% 6px 2%;font-family:"trebuchet MS",Verdana,sans-serif; 
 color:#FFF;background-color:#5C87B2; 
}#content{margin:0 0 0 2%;position:relative;} 
.summary-container,.content-container{background:#FFF;width:96%;margin-top:8px;padding:10px;position:relative;} 
.content-container p{margin:0 0 10px 0; 
}#details-left{width:35%;float:left;margin-right:2%; 
}#details-right{width:63%;float:left;overflow:hidden; 
}#server_version{width:96%;_height:1px;min-height:1px;margin:0 0 5px 0;padding:11px 2% 8px 2%;color:#FFFFFF; 
 background-color:#5A7FA5;border-bottom:1px solid #C1CFDD;border-top:1px solid #4A6C8E;font-weight:normal; 
 font-size:1em;color:#FFF;text-align:right; 
}#server_version p{margin:5px 0;} 
table{margin:4px 0 4px 0;width:100%;border:none;} 
td,th{vertical-align:top;padding:3px 0;text-align:left;font-weight:normal;border:none;} 
th{width:30%;text-align:right;padding-right:2%;font-weight:bold;} 
thead th{background-color:#ebebeb;width:25%; 
}#details-right th{width:20%;} 
table tr.alt td,table tr.alt th{} 
.highlight-code{color:#CC0000;font-weight:bold;font-style:italic;} 
.clear{clear:both;} 
.preferred{padding:0 5px 2px 5px;font-weight:normal;background:#006633;color:#FFF;font-size:.8em;} 
--> 
</style> 
 
</head> 
<body> 
<div id="content"> 
<div class="content-container"> 
  <h3>HTTP Error 401.0 - Unauthorized</h3> 
  <h4>You do not have permission to view this directory or page.</h4> 
</div> 
<div class="content-container"> 
 <fieldset><h4>Most likely causes:</h4> 
  <ul>  <li>The authenticated user does not have access to a resource needed to process the request.</li> </ul> 
 </fieldset> 
</div> 
<div class="content-container"> 
 <fieldset><h4>Things you can try:</h4> 
  <ul>  <li>Create a tracing rule to track failed requests for this HTTP status code. For more information about creating a tracing rule for failed requests, click <a href="http://go.microsoft.com/fwlink/?LinkID=66439">here</a>. </li> </ul> 
 </fieldset> 
</div> 
 
<div class="content-container"> 
 <fieldset><h4>Detailed Error Information:</h4> 
  <div id="details-left"> 
   <table border="0" cellpadding="0" cellspacing="0"> 
    <tr class="alt"><th>Module</th><td>&nbsp;&nbsp;&nbsp;ManagedPipelineHandler</td></tr> 
    <tr><th>Notification</th><td>&nbsp;&nbsp;&nbsp;ExecuteRequestHandler</td></tr> 
    <tr class="alt"><th>Handler</th><td>&nbsp;&nbsp;&nbsp;System.Web.Mvc.MvcHandler</td></tr> 
    <tr><th>Error Code</th><td>&nbsp;&nbsp;&nbsp;0x00000000</td></tr> 
     
   </table> 
  </div> 
  <div id="details-right"> 
   <table border="0" cellpadding="0" cellspacing="0"> 
    <tr class="alt"><th>Requested URL</th><td>&nbsp;&nbsp;&nbsp;http://innovate.mdsol.com:80/RaveWebServices/datasets/ClinicalAuditRecords.odm?studyoid=project%28dev%29&amp;startid=1&amp;per_page=100</td></tr> 
    <tr><th>Physical Path</th><td>&nbsp;&nbsp;&nbsp;C:\MedidataApp\Rave\Sites\hdcvcl01046\release\2020.3.1\20201216-e3d18e6253.23-46-42.2021-03-01\RaveWebServices\datasets\ClinicalAuditRecords.odm</td></tr> 
    <tr class="alt"><th>Logon Method</th><td>&nbsp;&nbsp;&nbsp;Anonymous</td></tr> 
    <tr><th>Logon User</th><td>&nbsp;&nbsp;&nbsp;Anonymous</td></tr> 
     
   </table> 
   <div class="clear"></div> 
  </div> 
 </fieldset> 
</div> 
 
<div class="content-container"> 
 <fieldset><h4>More Information:</h4> 
  This is the generic Access Denied error returned by IIS. Typically, there is a substatus code associated with this error that describes why the server denied the request. Check the IIS Log file to determine whether a substatus code is associated with this failure. 
  <p><a href="http://go.microsoft.com/fwlink/?LinkID=62293&amp;IIS70Error=401,0,0x00000000,14393">View more information &raquo;</a></p> 
  <p>Microsoft Knowledge Base Articles:</p> 
 <ul><li>907273</li></ul> 
 
 </fieldset> 
</div> 
</div> 
</body> 
</html> 
```