### PR TITLE
UTF8-compatibility

### DIFF
--- a/rwslib/rws_requests/request_utf8.py
+++ b/rwslib/rws_requests/request_utf8.py
@@ -1,0 +1,87 @@
+from rwslib.rws_requests import (
+    ClinicalStudiesRequest,
+    MetadataStudiesRequest,
+    StudyDatasetRequest,
+    StudySubjectsRequest,
+    StudyVersionRequest,
+    StudyVersionsRequest,
+)
+from rwslib.rws_requests.biostats_gateway import (
+    CVMetaDataRequest,
+    FormDataRequest,
+    ProjectMetaDataRequest,
+)
+from rwslib.rws_requests.odm_adapter import (
+    AuditRecordsRequest,
+    SitesMetadataRequest,
+    VersionFoldersRequest,
+)
+
+
+class UTF8Result:
+    UTF8_BOM = b"\xEF\xBB\xBF"
+    DEFAULT_REQUEST_ENCODING = "ISO-8859-1"
+
+    def result(self, response):
+        if response.content.startswith(self.UTF8_BOM):
+            response.encoding = "utf-8-sig"
+        elif (
+            response.encoding == self.DEFAULT_REQUEST_ENCODING
+            and response.apparent_encoding == "utf-8"
+        ):
+            # Force UTF-8 when request's default "ISO-8859-1" is used
+            response.encoding = "utf-8"
+
+        return super().result(response)
+
+
+class MetadataStudiesRequestUTF8(UTF8Result, MetadataStudiesRequest):
+    pass
+
+
+class SitesMetadataRequestUTF8(UTF8Result, SitesMetadataRequest):
+    pass
+
+
+class AuditRecordsRequestUTF8(UTF8Result, AuditRecordsRequest):
+    KNOWN_QUERY_OPTIONS = AuditRecordsRequest.KNOWN_QUERY_OPTIONS + ["unicode"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.unicode = True
+
+
+class ClinicalStudiesRequestUTF8(UTF8Result, ClinicalStudiesRequest):
+    pass
+
+
+class CVMetaDataRequestUTF8(UTF8Result, CVMetaDataRequest):
+    pass
+
+
+class StudyDatasetRequestUTF8(UTF8Result, StudyDatasetRequest):
+    pass
+
+
+class FormDataRequestUTF8(UTF8Result, FormDataRequest):
+    pass
+
+
+class ProjectMetaDataRequestUTF8(UTF8Result, ProjectMetaDataRequest):
+    pass
+
+
+class StudyVersionRequestUTF8(UTF8Result, StudyVersionRequest):
+    pass
+
+
+class VersionFoldersRequestUTF8(UTF8Result, VersionFoldersRequest):
+    pass
+
+
+class StudySubjectsRequestUTF8(UTF8Result, StudySubjectsRequest):
+    pass
+
+
+class StudyVersionsRequestUTF8(UTF8Result, StudyVersionsRequest):
+    pass


### PR DESCRIPTION
Hello :wave: 

As discussed in https://github.com/mdsol/rwslib/issues/115 , here's a proposal to improve the default encoding of RWS library based on what I did locally to solve the issue.

Here's a few points of attention:
- I didn't check the encoding specified in the XML in the end. As we are returning string and not bytes, the decoding is already done before we load the XML and I didn't want to peek into the result to see if there was and XML declaration or not.
- I put everything in a separated file to avoid making breaking changes on how RWS lib decode result. Up to you if you want to include or not theses changes at some point as the default
- I use the requests.apparent_encoding to double check that the data looks like it's utf-8 encoding when we are falling back on request's default.
- We also had to add `unicode=True` query parameter for the audit record data to be correctly sent from Rave


