### PR TITLE
Feature/optional last response preserving

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rwslib"
-version = "1.2.12"
+version = "1.2.13"
 description = "Rave Web Services for Python"
 authors = ["Ian Sparks <isparks@trialgrid.com>"]
 maintainers = ["Geoff Low <geoff.low@3ds.com>"]

--- a/rwslib/__init__.py
+++ b/rwslib/__init__.py
@@ -64,12 +64,13 @@ class RWSConnection(object):
         # Time taken to process last request
         self.request_time = None
 
-    def send_request(self, request_object, timeout=None, retries=1, **kwargs):
+    def send_request(self, request_object, timeout=None, retries=1, preserve_last_response=True, **kwargs):
         """Send request to RWS endpoint. The request object passed provides the URL endpoint and the HTTP method.
            Takes the text response from RWS and allows the request object to modify it for return. This allows the request
            object to return text, an XML document object, a CSV file or anything else that can be generated from the text
            response from RWS.
            A timeout, in seconds, can be optionally passed into send_request.
+           Preserving response in class can be disabled by setting `preserve_last_response=False`.
         """
         if not isinstance(request_object, RWSRequest):
             raise ValueError("Request object must be a subclass of RWSRequest")
@@ -113,7 +114,8 @@ class RWSConnection(object):
                 )
 
         self.request_time = time.time() - start_time
-        self.last_result = r  # see also r.elapsed for timedelta object.
+        if preserve_last_response:
+            self.last_result = r  # see also r.elapsed for timedelta object.
 
         if r.status_code in [400, 404]:
             # Is it a RWS response?

--- a/rwslib/__init__.py
+++ b/rwslib/__init__.py
@@ -99,19 +99,15 @@ class RWSConnection(object):
 
         try:
             r = action(full_url, **kwargs)  # type: requests.models.Response
-        except (
-            requests.exceptions.ConnectTimeout,
-            requests.exceptions.ReadTimeout,
-        ) as exc:
-            if isinstance(exc, (requests.exceptions.ConnectTimeout,)):
-                raise RWSException(
-                    "Server Connection Timeout",
-                    "Connection timeout for {}".format(full_url),
-                )
-            elif isinstance(exc, (requests.exceptions.ReadTimeout,)):
-                raise RWSException(
-                    "Server Read Timeout", "Read timeout for {}".format(full_url)
-                )
+        except requests.exceptions.ConnectTimeout:
+            raise RWSException(
+                "Server Connection Timeout",
+                "Connection timeout for {}".format(full_url),
+            )
+        except requests.exceptions.ReadTimeout:
+            raise RWSException(
+                "Server Read Timeout", "Read timeout for {}".format(full_url)
+            )
 
         self.request_time = time.time() - start_time
         if preserve_last_response:

--- a/tests/rwslib/test_rwslib.py
+++ b/tests/rwslib/test_rwslib.py
@@ -83,6 +83,24 @@ class TestVersion(unittest.TestCase):
         self.assertEqual(v, "1.0.0")
         self.assertEqual(rave.last_result.status_code, 200)
 
+    @httpretty.activate
+    def test_disable_response_preserving(self):
+        """A simple test, patching the get request so that it does not hit a website"""
+
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://innovate.mdsol.com/RaveWebServices/version",
+            status=200,
+            body="1.0.0",
+        )
+
+        # Now my test
+        rave = rwslib.RWSConnection("https://innovate.mdsol.com")
+        v = rave.send_request(rwslib.rws_requests.VersionRequest(), preserve_last_response=False)
+
+        self.assertEqual(v, "1.0.0")
+        self.assertEqual(rave.last_result, None)
+
 
 class TestMustBeRWSRequestSubclass(unittest.TestCase):
     """Test that request object passed must be RWSRequest subclass"""


### PR DESCRIPTION
Issue:
When fetching clinical data, there are cases where files exceeding 2 GB are being transferred. Currently, the client always retains the response object in a class property, which results in doubling the memory usage.

Solution:
In this pull request, I’ve made the preservation of the response object optional. This change reduces memory consumption by preventing the client from unnecessarily holding the response object in memory, especially for large file transfers.

Also: Error catching was refactored, test added, lib version updated