### PR TITLE
Updating factbook.yaml to get factbook_compliant in Policy Engine

### DIFF
--- a/factbook.yaml
+++ b/factbook.yaml
@@ -1,0 +1,31 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  json_schema: https://github.com/mdsol/platform-standards/blob/main/schemas/v1alpha1.schema.json
+  name: FIX_REQUIRED_NAME
+  description: FIX_REQUIRED_DESCRIPTION
+  people:
+    - role: technical owner
+      email: glow@mdsol.com
+    - role: product owner
+      email: Not Found in Factbook
+  teams:
+    - number: 214
+      name: Team 214
+  annotations:
+    runbook: No runbook found
+    healthcheck: NO HEALTH CHECK
+    product: Data Fabric
+  channels:
+    - url: FIX_REQUIRED_CHANNEL_URL
+      role: slack
+      automated_messaging: true
+      mention: FIX_REQUIRED_SLACK_MENTION
+    - url: FIX_REQUIRED_EMAIL_CHANNEL_URL
+      role: email
+      automated_messaging: false
+spec:
+  type: FIX_TYPE
+  lifecycle: FIX_REQUIRED_LIFECYCLE
+  owner: FIX_REQUIRED_OWNER
+  experience: enablement

--- a/factbook.yaml
+++ b/factbook.yaml
@@ -2,30 +2,20 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   json_schema: https://github.com/mdsol/platform-standards/blob/main/schemas/v1alpha1.schema.json
-  name: FIX_REQUIRED_NAME
-  description: FIX_REQUIRED_DESCRIPTION
+  name: rwslib
+  description: Rave Web Services for Python
   people:
     - role: technical owner
-      email: glow@mdsol.com
+      email: geoff.low@3ds.com
     - role: product owner
-      email: Not Found in Factbook
+      email: geoff.low@3ds.com
   teams:
     - number: 214
       name: Team 214
   annotations:
-    runbook: No runbook found
-    healthcheck: NO HEALTH CHECK
     product: Data Fabric
-  channels:
-    - url: FIX_REQUIRED_CHANNEL_URL
-      role: slack
-      automated_messaging: true
-      mention: FIX_REQUIRED_SLACK_MENTION
-    - url: FIX_REQUIRED_EMAIL_CHANNEL_URL
-      role: email
-      automated_messaging: false
 spec:
-  type: FIX_TYPE
-  lifecycle: FIX_REQUIRED_LIFECYCLE
-  owner: FIX_REQUIRED_OWNER
+  type: library
+  lifecycle: production
+  owner: geoff.low@3ds.com
   experience: enablement


### PR DESCRIPTION
# Background:
 Policy Engine will be live soon and will block PRs for non factbook_compliant repos. 
# Changes Made: 
We gathered data from various sources. Please verify if the data in the PR is correct and if that is wrong, feel free to add a commit to correct the data.
Policy engine expects experience, product and team information to be present in the factbook.yaml file to mark the repo to be compliant. 
# Impact: 
This is just a METADATA file change which is consumed by DevOps central and there would be no other code change we are requesting for. Hence, looking forward to getting this PR reviewed and merged after verification and correction of the data. 
# Contact: 
Please reach out to [ops-dev-enablement](https://app.slack.com/channels/C08L42T5WJ2)